### PR TITLE
Add states feature

### DIFF
--- a/SALIERI/package.json
+++ b/SALIERI/package.json
@@ -21,9 +21,7 @@
     "@tiptap/core": "^2.12.0",
     "@tiptap/pm": "^2.12.0",
     "@tiptap/starter-kit": "^2.12.0",
-    "codemirror": "^6.0.1",
-    "regex": "1.10",
-    "indexmap": "{ version = 2.0, features = [serde] }"
+    "codemirror": "^6.0.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.6",

--- a/SALIERI/src-tauri/src/main.rs
+++ b/SALIERI/src-tauri/src/main.rs
@@ -6,12 +6,14 @@ mod pomodoro;
 mod tasks;
 mod commands;
 mod fileaccess;
+mod states;
 
 use crate::theme::{set_theme, get_current_theme, ThemeChangedPayload, THEME_KEY, DEFAULT_THEME, SETTINGS_STORE_FILENAME};
-use crate::tasks::{get_tasks, start_task_timer_loop, clear_active_startup, get_current_logical_day_key};
+use crate::tasks::{get_tasks, start_task_timer_loop, clear_active_startup, get_current_logical_day_key, create_task};
 use crate::pomodoro::init_pomodoro;
 use crate::commands::handle_palette_command;
 use crate::fileaccess::save_file;
+use crate::states::{list_states, create_state, edit_state, delete_state};
 
 use serde_json::json;
 use tauri_plugin_store::StoreExt;
@@ -58,9 +60,14 @@ fn main() {
             set_theme,
             get_current_theme,
             handle_palette_command,
-            get_tasks
-            ,get_current_logical_day_key,
+            get_tasks,
+            get_current_logical_day_key,
             save_file,
+            create_task,
+            list_states,
+            create_state,
+            edit_state,
+            delete_state,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/SALIERI/src-tauri/src/states.rs
+++ b/SALIERI/src-tauri/src/states.rs
@@ -1,0 +1,135 @@
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use uuid::Uuid;
+use lazy_static::lazy_static;
+use std::time::Duration;
+use std::{fs, path::{Path, PathBuf}};
+use directories::ProjectDirs;
+use tokio::sync::Mutex as TokioMutex;
+use indexmap::IndexMap;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct State {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(with = "duration_format")]
+    pub total_time: Duration,
+}
+
+mod duration_format {
+    use super::*;
+    use serde::{Serializer, Deserializer};
+
+    pub fn serialize<S>(d: &Duration, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_u64(d.as_secs())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
+
+type Store = IndexMap<String, State>;
+
+fn load_store_for_static_init() -> Store {
+    match load_json(&store_path()) {
+        Ok(store) => store,
+        Err(_) => {
+            let empty = Store::new();
+            let _ = save_json(&store_path(), &empty);
+            empty
+        }
+    }
+}
+
+lazy_static! {
+    static ref STATE_STORE: TokioMutex<Store> = TokioMutex::new(load_store_for_static_init());
+}
+
+fn data_dir() -> PathBuf {
+    ProjectDirs::from("com", "salieri", "salieri")
+        .map(|d| d.data_local_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn store_path() -> PathBuf { data_dir().join("states_store.json") }
+
+fn ensure_data_dir() {
+    let dir = data_dir();
+    if !dir.exists() { let _ = fs::create_dir_all(&dir); }
+}
+
+fn load_json<T: DeserializeOwned>(p: &Path) -> Result<T, String> {
+    if !p.exists() { return Err("missing".into()); }
+    serde_json::from_str(&fs::read_to_string(p).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())
+}
+
+fn save_json<T: Serialize>(p: &Path, d: &T) -> Result<(), String> {
+    ensure_data_dir();
+    fs::write(p, serde_json::to_string_pretty(d).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())
+}
+
+async fn persist_global_store() -> Result<(), String> {
+    let guard = STATE_STORE.lock().await;
+    let data = guard.clone();
+    drop(guard);
+    tauri::async_runtime::spawn_blocking(move || save_json(&store_path(), &data))
+        .await
+        .map_err(|e| format!("Failed to join save state: {}", e))?
+        .map_err(|e| format!("Failed to save state: {}", e))
+}
+
+#[tauri::command]
+pub async fn list_states() -> Result<Vec<State>, String> {
+    let guard = STATE_STORE.lock().await;
+    Ok(guard.values().cloned().collect())
+}
+
+#[tauri::command]
+pub async fn create_state(name: String) -> Result<State, String> {
+    let mut guard = STATE_STORE.lock().await;
+    let state = State { id: Uuid::new_v4(), name, total_time: Duration::from_secs(0) };
+    guard.insert(state.id.to_string(), state.clone());
+    drop(guard);
+    persist_global_store().await?;
+    Ok(state)
+}
+
+#[tauri::command]
+pub async fn edit_state(id: String, name: String) -> Result<(), String> {
+    let mut guard = STATE_STORE.lock().await;
+    if let Some(st) = guard.get_mut(&id) {
+        st.name = name;
+        drop(guard);
+        persist_global_store().await
+    } else {
+        Err("state not found".into())
+    }
+}
+
+#[tauri::command]
+pub async fn delete_state(id: String) -> Result<(), String> {
+    let mut guard = STATE_STORE.lock().await;
+    guard.remove(&id);
+    drop(guard);
+    persist_global_store().await
+}
+
+pub async fn increment_total_time(id: &str, secs: u64) {
+    let mut guard = STATE_STORE.lock().await;
+    if let Some(st) = guard.get_mut(id) {
+        st.total_time += Duration::from_secs(secs);
+    }
+}
+
+pub async fn persist() -> Result<(), String> {
+    persist_global_store().await
+}

--- a/SALIERI/src/lib/stores.ts
+++ b/SALIERI/src/lib/stores.ts
@@ -12,6 +12,14 @@ export type Task = {
 
 export const tasks = writable<Task[]>([]);
 
+export type State = {
+  id: string;
+  name: string;
+  total_time: number;
+};
+
+export const states = writable<State[]>([]);
+
 // Create a custom store that handles persistence
 function createThemeStore() {
     const { subscribe, set, update } = writable<'light' | 'dark'>('dark');


### PR DESCRIPTION
## Summary
- implement `states.rs` for state management and persistence
- expand `Task` with `state_id`
- add `create_task` and state API commands
- update timer loop to add time to states
- add state management UI and task creation state selection

## Testing
- `cargo check` *(fails: failed to fetch tauri-plugin-store due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684a3907ad3c8325b2a240446984f399