### PR TITLE
Add states feature

### DIFF
--- a/SALIERI/src-tauri/src/commands.rs
+++ b/SALIERI/src-tauri/src/commands.rs
@@ -3,6 +3,7 @@ use tauri::AppHandle;
 
 use crate::theme::{set_theme, get_current_theme};
 use crate::tasks::{command_todo, command_doing, command_done, command_break, command_completed, command_deleteT};
+use crate::states::command_state;
 use crate::pomodoro::{command_start_pomodoro, command_pause_pomodoro, command_stop_pomodoro, command_resume_pomodoro};
 use crate::fileaccess::{command_code};
 
@@ -70,7 +71,8 @@ pub async fn handle_palette_command(command: String, app_handle: AppHandle, days
         Some(&"/code") => command_code(&parts, app_handle).await,
         Some(&"/write") => command_code(&parts, app_handle).await,
         Some(&"/wq") => command_wq(),
+        Some(&"/state") => command_state(&parts).await,
         Some(unknown_cmd) => Err(format!("unknown command: {}", unknown_cmd)),
-        None => Err("empty command received".into()), 
+        None => Err("empty command received".into()),
     }
 }

--- a/SALIERI/src-tauri/src/main.rs
+++ b/SALIERI/src-tauri/src/main.rs
@@ -9,8 +9,11 @@ mod fileaccess;
 mod states;
 
 use crate::theme::{set_theme, get_current_theme, ThemeChangedPayload, THEME_KEY, DEFAULT_THEME, SETTINGS_STORE_FILENAME};
-use crate::tasks::{get_tasks, start_task_timer_loop, clear_active_startup, get_current_logical_day_key, create_task};
-use crate::states::{create_state, edit_state, delete_state, list_states};
+use crate::tasks::{get_tasks, start_task_timer_loop, clear_active_startup, get_current_logical_day_key};
+use crate::states::{
+    create_state, edit_state, delete_state, list_states,
+    command_state, get_active_state,
+};
 use crate::pomodoro::init_pomodoro;
 use crate::commands::handle_palette_command;
 use crate::fileaccess::save_file;
@@ -63,11 +66,12 @@ fn main() {
             get_tasks,
             get_current_logical_day_key,
             save_file,
-            create_task,
             create_state,
             edit_state,
             delete_state,
             list_states,
+            command_state,
+            get_active_state,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/SALIERI/src-tauri/src/main.rs
+++ b/SALIERI/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ use crate::theme::{set_theme, get_current_theme, ThemeChangedPayload, THEME_KEY,
 use crate::tasks::{get_tasks, start_task_timer_loop, clear_active_startup, get_current_logical_day_key};
 use crate::states::{
     create_state, edit_state, delete_state, list_states,
-    command_state, get_active_state,
+    get_active_state,
 };
 use crate::pomodoro::init_pomodoro;
 use crate::commands::handle_palette_command;
@@ -70,7 +70,6 @@ fn main() {
             edit_state,
             delete_state,
             list_states,
-            command_state,
             get_active_state,
         ])
         .run(tauri::generate_context!())

--- a/SALIERI/src-tauri/src/main.rs
+++ b/SALIERI/src-tauri/src/main.rs
@@ -6,9 +6,11 @@ mod pomodoro;
 mod tasks;
 mod commands;
 mod fileaccess;
+mod states;
 
 use crate::theme::{set_theme, get_current_theme, ThemeChangedPayload, THEME_KEY, DEFAULT_THEME, SETTINGS_STORE_FILENAME};
-use crate::tasks::{get_tasks, start_task_timer_loop, clear_active_startup, get_current_logical_day_key};
+use crate::tasks::{get_tasks, start_task_timer_loop, clear_active_startup, get_current_logical_day_key, create_task};
+use crate::states::{create_state, edit_state, delete_state, list_states};
 use crate::pomodoro::init_pomodoro;
 use crate::commands::handle_palette_command;
 use crate::fileaccess::save_file;
@@ -58,9 +60,14 @@ fn main() {
             set_theme,
             get_current_theme,
             handle_palette_command,
-            get_tasks
-            ,get_current_logical_day_key,
+            get_tasks,
+            get_current_logical_day_key,
             save_file,
+            create_task,
+            create_state,
+            edit_state,
+            delete_state,
+            list_states,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/SALIERI/src-tauri/src/states.rs
+++ b/SALIERI/src-tauri/src/states.rs
@@ -1,0 +1,113 @@
+use std::{collections::HashMap, fs, path::{Path, PathBuf}, time::Duration};
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use uuid::Uuid;
+use lazy_static::lazy_static;
+use directories::ProjectDirs;
+use tokio::sync::Mutex as TokioMutex;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct State {
+    pub id: Uuid,
+    pub name: String,
+    pub total_time: Duration,
+}
+
+type StateStore = HashMap<Uuid, State>;
+
+fn load_store_for_static_init() -> StateStore {
+    match load_json(&store_path()) {
+        Ok(store) => store,
+        Err(_) => {
+            let empty: StateStore = HashMap::new();
+            let _ = save_json(&store_path(), &empty);
+            empty
+        }
+    }
+}
+
+lazy_static! {
+    static ref STATE_STORE: TokioMutex<StateStore> = TokioMutex::new(load_store_for_static_init());
+}
+
+fn data_dir() -> PathBuf {
+    ProjectDirs::from("com", "salieri", "salieri")
+        .map(|d| d.data_local_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn store_path() -> PathBuf { data_dir().join("states_store.json") }
+
+fn ensure_data_dir() {
+    let dir = data_dir();
+    if !dir.exists() { let _ = fs::create_dir_all(&dir); }
+}
+
+fn load_json<T: DeserializeOwned>(p: &Path) -> Result<T, String> {
+    if !p.exists() { return Err("missing".into()); }
+    serde_json::from_str(&fs::read_to_string(p).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())
+}
+
+fn save_json<T: Serialize>(p: &Path, d: &T) -> Result<(), String> {
+    ensure_data_dir();
+    fs::write(p, serde_json::to_string_pretty(d).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())
+}
+
+async fn persist_state_store() -> Result<(), String> {
+    let store_guard = STATE_STORE.lock().await;
+    let data = store_guard.clone();
+    drop(store_guard);
+    tauri::async_runtime::spawn_blocking(move || save_json(&store_path(), &data))
+        .await
+        .map_err(|e| format!("Failed to join save state: {}", e))?
+        .map_err(|e| format!("Failed to save state store: {}", e))
+}
+
+#[tauri::command]
+pub async fn create_state(name: String) -> Result<State, String> {
+    let mut guard = STATE_STORE.lock().await;
+    let state = State { id: Uuid::new_v4(), name, total_time: Duration::from_secs(0) };
+    guard.insert(state.id, state.clone());
+    drop(guard);
+    persist_state_store().await?;
+    Ok(state)
+}
+
+#[tauri::command]
+pub async fn edit_state(id: String, name: String) -> Result<String, String> {
+    let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
+    let mut guard = STATE_STORE.lock().await;
+    let Some(st) = guard.get_mut(&uuid) else { return Err("state not found".into()); };
+    st.name = name;
+    drop(guard);
+    persist_state_store().await?;
+    Ok("edited".into())
+}
+
+#[tauri::command]
+pub async fn delete_state(id: String) -> Result<String, String> {
+    let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
+    let mut guard = STATE_STORE.lock().await;
+    guard.remove(&uuid);
+    drop(guard);
+    persist_state_store().await?;
+    Ok("deleted".into())
+}
+
+#[tauri::command]
+pub async fn list_states() -> Result<Vec<State>, String> {
+    let guard = STATE_STORE.lock().await;
+    Ok(guard.values().cloned().collect())
+}
+
+pub async fn increment_total_time(id: &str, dur: Duration) -> Result<(), String> {
+    let uuid = Uuid::parse_str(id).map_err(|e| e.to_string())?;
+    let mut guard = STATE_STORE.lock().await;
+    if let Some(st) = guard.get_mut(&uuid) {
+        st.total_time += dur;
+    }
+    Ok(())
+}
+
+pub async fn persist_states() -> Result<(), String> { persist_state_store().await }

--- a/SALIERI/src-tauri/src/states.rs
+++ b/SALIERI/src-tauri/src/states.rs
@@ -149,7 +149,6 @@ pub async fn increment_active_state(dur: Duration) -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command]
 pub async fn command_state(parts: &[&str]) -> Result<String, String> {
     if parts.len() < 2 { return Err("usage: /state [name]".into()); }
     let name = parts[1..].join(" ");

--- a/SALIERI/src-tauri/src/tasks.rs
+++ b/SALIERI/src-tauri/src/tasks.rs
@@ -1,8 +1,7 @@
 use chrono::{Local, Duration as ChronoDuration, NaiveDate};
 use tauri::AppHandle;
 use uuid::Uuid;
-use once_cell::sync::Lazy;
-use std::{collections::HashMap, fs, path::{Path, PathBuf}, sync::Mutex, time::Duration};
+use std::{fs, path::{Path, PathBuf}, time::Duration};
 use directories::ProjectDirs;
 use tokio::sync::RwLock as TokioRwLock;
 use futures::executor;         
@@ -11,7 +10,14 @@ use tokio::sync::Mutex as TokioMutex;
 use lazy_static::lazy_static;
 use indexmap::IndexMap;
 
-use crate::states::{increment_total_time, persist_states};
+use crate::states::{
+    increment_total_time,
+    persist_states,
+    increment_active_state,
+    get_state_by_name,
+    clear_active_state,
+    set_active_state,
+};
 
 use crate::user::increment_tasks_done;
 

--- a/SALIERI/src-tauri/src/tasks.rs
+++ b/SALIERI/src-tauri/src/tasks.rs
@@ -11,6 +11,8 @@ use tokio::sync::Mutex as TokioMutex;
 use lazy_static::lazy_static;
 use indexmap::IndexMap;
 
+use crate::states::{increment_total_time, persist_states};
+
 use crate::user::increment_tasks_done;
 
 fn load_store_for_static_init() -> Store { // Renamed for clarity of purpose
@@ -81,9 +83,11 @@ type LogicalDay  = String;
 pub struct Task {
     pub id: String,
     pub title: String,
-    pub status: String,     
-    pub created_at: String, 
-    pub time_spent: u64,   
+    pub status: String,
+    pub created_at: String,
+    pub time_spent: u64,
+    #[serde(default)]
+    pub state_id: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
@@ -187,19 +191,28 @@ pub fn start_task_timer_loop(_h: AppHandle) {
             let mut store_guard = TASK_STORE.lock().await;
             let today = today_key(0);
             let mut changed_in_loop = false;
+            let mut state_for_tick: Option<String> = None;
             if let Some(bucket) = store_guard.get_mut(&today) {
                 if let Some(task) = bucket.todo.get_mut(&id) {
                     if task.status == "doing" {
                         task.time_spent += 1;
                         changed_in_loop = true;
+                        state_for_tick = task.state_id.clone();
                     }
                 }
             }
-            drop(store_guard); 
+            drop(store_guard);
 
-            if changed_in_loop && tick_count % 60 == 0 { 
+            if let Some(sid) = state_for_tick {
+                let _ = increment_total_time(&sid, Duration::from_secs(1)).await;
+            }
+
+            if changed_in_loop && tick_count % 60 == 0 {
                 if let Err(e) = persist_global_store().await {
                     eprintln!("Timer loop failed to save store: {}", e);
+                }
+                if let Err(e) = persist_states().await {
+                    eprintln!("Timer loop failed to save states: {}", e);
                 }
             }
         }
@@ -238,7 +251,7 @@ pub async fn command_todo(parts: &[&str], _app: AppHandle) -> Result<String, Str
         return Err("duplicate title".into());
     }
 
-    let task = Task { id: Uuid::new_v4().to_string(), title: title.clone(), status: "todo".into(), created_at: day.clone(), time_spent: 0 };
+    let task = Task { id: Uuid::new_v4().to_string(), title: title.clone(), status: "todo".into(), created_at: day.clone(), time_spent: 0, state_id: None };
     bucket.todo.insert(task.id.clone(), task);
 
     let store_data_to_save = store_guard.clone(); 
@@ -250,6 +263,33 @@ pub async fn command_todo(parts: &[&str], _app: AppHandle) -> Result<String, Str
         .map_err(|e| format!("Failed to save store: {}", e))?;
 
     Ok("added".into())
+}
+
+#[tauri::command]
+pub async fn create_task(title: String, state_id: Option<String>) -> Result<Task, String> {
+    if title.trim().is_empty() { return Err("need task title".into()); }
+    let day = today_key(0);
+    let mut store_guard = TASK_STORE.lock().await;
+    let bucket = bucket_mut(&mut *store_guard, &day);
+    if bucket.todo.values().any(|t| t.title == title) || bucket.done.values().any(|t| t.title == title) {
+        return Err("duplicate title".into());
+    }
+    let task = Task {
+        id: Uuid::new_v4().to_string(),
+        title: title.clone(),
+        status: "todo".into(),
+        created_at: day.clone(),
+        time_spent: 0,
+        state_id,
+    };
+    bucket.todo.insert(task.id.clone(), task.clone());
+    let store_data_to_save = store_guard.clone();
+    drop(store_guard);
+    tauri::async_runtime::spawn_blocking(move || save_json(&store_path(), &store_data_to_save))
+        .await
+        .map_err(|e| format!("Failed to join save task: {}", e))?
+        .map_err(|e| format!("Failed to save store: {}", e))?;
+    Ok(task)
 }
 
 // ─── /doing

--- a/SALIERI/src/lib/stores.ts
+++ b/SALIERI/src/lib/stores.ts
@@ -12,6 +12,14 @@ export type Task = {
 
 export const tasks = writable<Task[]>([]);
 
+export type State = {
+  id: string;
+  name: string;
+  total_time: { secs: number; nanos: number };
+};
+
+export const states = writable<State[]>([]);
+
 // Create a custom store that handles persistence
 function createThemeStore() {
     const { subscribe, set, update } = writable<'light' | 'dark'>('dark');

--- a/SALIERI/src/lib/stores.ts
+++ b/SALIERI/src/lib/stores.ts
@@ -19,6 +19,7 @@ export type State = {
 };
 
 export const states = writable<State[]>([]);
+export const activeState = writable<State | null>(null);
 
 // Create a custom store that handles persistence
 function createThemeStore() {


### PR DESCRIPTION
## Summary
- implement state tracking backend and persist to states_store.json
- add optional state_id on tasks and create `create_task` command
- update timer loop to count time toward states
- expose CRUD state commands
- load states on the frontend and show management UI
- allow assigning a state when creating tasks

## Testing
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a47dabebc832584c7d5097530ec08