### PR TITLE
Remove task nav buttons, rename delete command

### DIFF
--- a/SALIERI/src-tauri/src/commands.rs
+++ b/SALIERI/src-tauri/src/commands.rs
@@ -2,7 +2,7 @@ use chrono::Local;
 use tauri::AppHandle;
 
 use crate::theme::{set_theme, get_current_theme};
-use crate::tasks::{command_todo, command_doing, command_done, command_break, command_completed, command_deleteT};
+use crate::tasks::{command_todo, command_doing, command_done, command_break, command_completed, command_delete};
 use crate::pomodoro::{command_start_pomodoro, command_pause_pomodoro, command_stop_pomodoro, command_resume_pomodoro};
 use crate::fileaccess::{command_code};
 
@@ -61,7 +61,7 @@ pub async fn handle_palette_command(command: String, app_handle: AppHandle, days
         Some(&"/doing") => command_doing(&parts, app_handle, days_offset).await,
         Some(&"/done") => command_done(&parts, app_handle, days_offset).await,
         Some(&"/break") => command_break(&parts, app_handle).await,
-        Some(&"/deleteT") => command_deleteT(&parts, app_handle).await,
+        Some(&"/delete") => command_delete(&parts, app_handle).await,
         Some(&"/completed") => command_completed(), 
         Some(&"/start") => command_start_pomodoro().await,
         Some(&"/pause") => command_pause_pomodoro().await,

--- a/SALIERI/src-tauri/src/tasks.rs
+++ b/SALIERI/src-tauri/src/tasks.rs
@@ -370,9 +370,9 @@ pub async fn command_break(parts: &[&str], _app: AppHandle) -> Result<String, St
     }
 }
 
-// ─── /deleteT 
+// ─── /delete
 // add offset stuff
-pub async fn command_deleteT(parts: &[&str], _app: AppHandle) -> Result<String, String> { 
+pub async fn command_delete(parts: &[&str], _app: AppHandle) -> Result<String, String> {
     ensure_title!(parts);
     let title = parts[1..].join(" ");
 

--- a/SALIERI/src/routes/+page.svelte
+++ b/SALIERI/src/routes/+page.svelte
@@ -52,7 +52,7 @@
     { cmd: '/doing [task]', desc: 'start working on task' },
     { cmd: '/done [task]', desc: 'mark task complete' },
     { cmd: '/break [task]', desc: 'pause current task' },
-    { cmd: '/deleteT [task]', desc: 'delete task' },
+    { cmd: '/delete [task]', desc: 'delete task' },
     { cmd: '/start', desc: 'begin pomodoro' },
     { cmd: '/pause', desc: 'pause timer' },
     { cmd: '/resume', desc: 'resume timer' },
@@ -434,7 +434,6 @@ const payload = { days_offset: currentDayOffset };
       <div class="task-section">
         <h3>todo</h3>
         <div class="task-list">
-          <button on:click={handlePrev}>prev</button>
           {#if todoTasks.length === 0}
             <div class="empty-state">all clear</div>
           {:else}
@@ -445,7 +444,6 @@ const payload = { days_offset: currentDayOffset };
               </div>
             {/each}
           {/if}
-        <button on:click={handleNext}>next</button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- remove prev/next task navigation buttons
- rename `/deleteT` command to `/delete`

## Testing
- `npm run check` *(fails: `svelte-kit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a50a99f308325aae03a0be818ac79