### PR TITLE
Ordered states & UI cleanup

### DIFF
--- a/SALIERI/package.json
+++ b/SALIERI/package.json
@@ -21,9 +21,7 @@
     "@tiptap/core": "^2.12.0",
     "@tiptap/pm": "^2.12.0",
     "@tiptap/starter-kit": "^2.12.0",
-    "codemirror": "^6.0.1",
-    "regex": "1.10",
-    "indexmap": "{ version = 2.0, features = [serde] }"
+    "codemirror": "^6.0.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.6",

--- a/SALIERI/src-tauri/src/commands.rs
+++ b/SALIERI/src-tauri/src/commands.rs
@@ -2,7 +2,7 @@ use chrono::Local;
 use tauri::AppHandle;
 
 use crate::theme::{set_theme, get_current_theme};
-use crate::tasks::{command_todo, command_doing, command_done, command_break, command_completed, command_deleteT};
+use crate::tasks::{command_todo, command_doing, command_done, command_break, command_completed, command_delete};
 use crate::states::command_state;
 use crate::pomodoro::{command_start_pomodoro, command_pause_pomodoro, command_stop_pomodoro, command_resume_pomodoro};
 use crate::fileaccess::{command_code};
@@ -62,7 +62,7 @@ pub async fn handle_palette_command(command: String, app_handle: AppHandle, days
         Some(&"/doing") => command_doing(&parts, app_handle, days_offset).await,
         Some(&"/done") => command_done(&parts, app_handle, days_offset).await,
         Some(&"/break") => command_break(&parts, app_handle).await,
-        Some(&"/deleteT") => command_deleteT(&parts, app_handle).await,
+        Some(&"/delete") => command_delete(&parts, app_handle).await,
         Some(&"/completed") => command_completed(), 
         Some(&"/start") => command_start_pomodoro().await,
         Some(&"/pause") => command_pause_pomodoro().await,

--- a/SALIERI/src/routes/+page.svelte
+++ b/SALIERI/src/routes/+page.svelte
@@ -480,12 +480,16 @@ const payload = { days_offset: currentDayOffset };
       <div class="states-section">
         <h3>states</h3>
         <div class="state-list">
-          {#each $states as st}
-            <div class="state-item">
-              <span>{st.name}</span>
-              <span>{Math.floor(st.total_time.secs / 60)}m</span>
-            </div>
-          {/each}
+          {#if $states.length === 0}
+            <div class="empty-state">no states yet</div>
+          {:else}
+            {#each $states as st}
+              <div class="state-item">
+                <span>{st.name}</span>
+                <span>{Math.floor(st.total_time.secs / 60)}m</span>
+              </div>
+            {/each}
+          {/if}
         </div>
       </div>
 

--- a/SALIERI/src/routes/+page.svelte
+++ b/SALIERI/src/routes/+page.svelte
@@ -47,15 +47,13 @@
   let tiptapBool = false;
   let currentDayOffset = 0;
 
-  let editingStateId: string | null = null;
-  let editingStateName = '';
 
   const commands = [
     { cmd: '/todo [task]', desc: 'add new task' },
     { cmd: '/doing [task]', desc: 'start working on task' },
     { cmd: '/done [task]', desc: 'mark task complete' },
     { cmd: '/break [task]', desc: 'pause current task' },
-    { cmd: '/deleteT [task]', desc: 'delete task' },
+    { cmd: '/delete [task|state]', desc: 'delete task or state' },
     { cmd: '/start', desc: 'begin pomodoro' },
     { cmd: '/pause', desc: 'pause timer' },
     { cmd: '/resume', desc: 'resume timer' },
@@ -282,22 +280,7 @@ const payload = { days_offset: currentDayOffset };
     }
   }
 
-  async function removeState(id: string) {
-    await invoke('delete_state', { id });
-    states.update(s => s.filter(st => st.id !== id));
-  }
 
-  function startEditState(id: string, name: string) {
-    editingStateId = id;
-    editingStateName = name;
-  }
-
-  async function saveEditState(id: string) {
-    await invoke('edit_state', { id, name: editingStateName });
-    states.update(s => s.map(st => st.id === id ? { ...st, name: editingStateName } : st));
-    editingStateId = null;
-    editingStateName = '';
-  }
 
 
   async function toggleEditor(pathToLoad: string | null = null) {
@@ -467,7 +450,6 @@ const payload = { days_offset: currentDayOffset };
       <div class="task-section">
         <h3>todo</h3>
         <div class="task-list">
-          <button on:click={handlePrev}>prev</button>
           {#if todoTasks.length === 0}
             <div class="empty-state">all clear</div>
           {:else}
@@ -478,7 +460,6 @@ const payload = { days_offset: currentDayOffset };
               </div>
             {/each}
           {/if}
-        <button on:click={handleNext}>next</button>
         </div>
       </div>
 
@@ -501,15 +482,8 @@ const payload = { days_offset: currentDayOffset };
         <div class="state-list">
           {#each $states as st}
             <div class="state-item">
-              {#if editingStateId === st.id}
-                <input bind:value={editingStateName} />
-                <button on:click={() => saveEditState(st.id)}>save</button>
-              {:else}
-                <span>{st.name}</span>
-                <span>{Math.floor(st.total_time.secs / 60)}m</span>
-                <button on:click={() => startEditState(st.id, st.name)}>edit</button>
-                <button on:click={() => removeState(st.id)}>x</button>
-              {/if}
+              <span>{st.name}</span>
+              <span>{Math.floor(st.total_time.secs / 60)}m</span>
             </div>
           {/each}
         </div>


### PR DESCRIPTION
## Summary
- keep `states_store.json` in insertion order using `IndexMap`
- add `/delete` command for tasks and states
- drop edit/delete UI for states
- remove prev/next buttons from tasks list

## Testing
- `cargo check` *(fails: glib-2.0 missing)*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5557b4548325bab92308a246deaf